### PR TITLE
Add docker client to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@ RUN apt-get update -qq && apt-get install -y -qq\
 # There are both ARG and ENV lines to make sure the value persists.
 # See https://docs.docker.com/engine/reference/builder/#/arg
 ARG AEGIR_UID=12345
-ENV AEGIR_UID ${AEGIR_UID:-12345}
+#ENV AEGIR_UID ${AEGIR_UID:-12345}
 
 ARG AEGIR_GID=12345
-ENV AEGIR_GID ${AEGIR_GID:-12345}
+#ENV AEGIR_GID ${AEGIR_GID:-12345}
 
 RUN echo "Creating user aegir with UID $AEGIR_UID and GID $AEGIR_GID"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,8 @@ RUN wget -q https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 && \
     chmod +x /usr/bin/docker
 
 # Add the docker group and add aegir to it.
-RUN groupadd docker
+ARG DOCKER_GID=1001
+RUN addgroup --gid $DOCKER_GID docker
 RUN adduser aegir docker
 
 USER aegir

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,15 @@ RUN mkdir /var/log/aegir
 RUN chown aegir:aegir /var/log/aegir
 RUN echo 'Hello, Aegir.' > /var/log/aegir/system.log
 
+# Install the docker client into the container.
+RUN wget -q https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 && \
+    cp docker-1.9.1 /usr/bin/docker && \
+    chmod +x /usr/bin/docker
+
+# Add the docker group and add aegir to it.
+RUN groupadd docker
+RUN adduser aegir docker
+
 USER aegir
 
 # You may change this environment at run time. User UID 1 is created with this email address.

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -9,10 +9,9 @@ FROM aegir/hostmaster
 #   docker build --build-arg AEGIR_UID=1000 -t aegir/hostmaster:local -f Dockerfile-local .
 
 ARG AEGIR_UID=1000
-ENV AEGIR_UID ${AEGIR_UID:-1000}
 
 USER root
-RUN echo "Changing aegir user's UID to ${AEGIR_UID} ..."
+RUN echo "Changing aegir user's UID to $AEGIR_UID ..."
 RUN usermod -u $AEGIR_UID aegir
 RUN groupmod -g $AEGIR_UID aegir
 RUN chown aegir:aegir /var/aegir -R

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -37,10 +37,10 @@ echo "Client Name: $AEGIR_CLIENT_NAME"
 echo "Client Email: $AEGIR_CLIENT_EMAIL"
 
 echo "-------------------------"
-echo "Running: drush hostmaster-install"
-
+echo "Running: drush cc drush"
 drush cc drush
 
+echo "Running: drush hostmaster-install"
 drush hostmaster-install -y --strict=0 $HOSTNAME \
   --aegir_db_host=$AEGIR_DATABASE_SERVER \
   --aegir_db_pass=$MYSQL_ROOT_PASSWORD \


### PR DESCRIPTION
In order for us to break out of the aegir shell (and actually scale aegir with docker) we need hostmaster to control docker.

This PR adds the Docker Client, inspired by Rancher Agent.

With this new image, if you mount /var/run/docker.sock and set the container to privileged, the Aegir user can run `docker ps` and get a list from inside the container!

This means that we can now create a new Provision web server class that uses docker instead of apache and restarts the containers instead of restarting the web server
