### PR TITLE
Improve dockerfiles to make releasable images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,12 @@ before_install:
 
   - cd ..
 
-  # First build stock image.
+  # First build stock image, and one for own user.
   - sudo docker build --rm -t aegir/hostmaster .
+  - sudo docker build --rm -t aegir/hostmaster:own --build-arg AEGIR_UID=1000 .
 
-  # Then build local image. Only difference is UID defaults to 1000
-  - sudo docker build  --build-arg AEGIR_UID=1000 --rm -t aegir/hostmaster:local -f Dockerfile-local .
+  # Then build local image. Only difference is /var/aegir is volume.
+  - sudo docker build --rm -t aegir/hostmaster:local -f Dockerfile-local .
 
   # Then build test image. Only difference is CMD defaults to run-tests.sh
   - sudo docker build --rm -t aegir/hostmaster:test -f Dockerfile-test .

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,17 @@ RUN mkdir /var/log/aegir
 RUN chown aegir:aegir /var/log/aegir
 RUN echo 'Hello, Aegir.' > /var/log/aegir/system.log
 
+# Install Provision for all.
+ENV PROVISION_VERSION 7.x-3.x
+RUN mkdir -p /usr/share/drush/commands
+RUN drush dl --destination=/usr/share/drush/commands provision-$PROVISION_VERSION -y
+
+RUN drush dl --destination=/usr/share/drush/commands registry_rebuild-7.x -y
+
 USER aegir
+
+RUN mkdir /var/aegir/config
+RUN mkdir /var/aegir/.drush
 
 # You may change this environment at run time. User UID 1 is created with this email address.
 ENV AEGIR_CLIENT_EMAIL aegir@aegir.docker
@@ -81,19 +91,8 @@ ENV AEGIR_MAKEFILE http://cgit.drupalcode.org/provision/plain/aegir.make
 # For Releases:
 # ENV AEGIR_MAKEFILE http://cgit.drupalcode.org/provision/plain/aegir-release.make?h=$AEGIR_VERSION
 
-VOLUME /var/aegir
-
-# This isn't working, I think because /var/aegir is set as a volume.
-# I've moved it bak to the docker-entrypoint.sh which allows us to dynamially set the version as an environment variable.
-# Since we have to wait for the MySQL container to initiate also, this does not result in any further delay.
-
-# Install Provision
-#RUN mkdir -p /var/aegir/.drush/commands
-#RUN drush dl --destination=/var/aegir/.drush/commands provision-$PROVISION_VERSION -y
-#RUN drush cc drush
-
-# Prepare hostmaster platform.
-# RUN drush make $AEGIR_MAKEFILE /var/aegir/$AEGIR_PROFILE-$AEGIR_VERSION
+VOLUME /var/aegir/config
+VOLUME /var/aegir/.drush
 
 # docker-entrypoint.sh waits for mysql and runs hostmaster install
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,10 @@ RUN apt-get update -qq && apt-get install -y -qq\
 ARG AEGIR_UID=12345
 ENV AEGIR_UID ${AEGIR_UID:-12345}
 
-ARG AEGIR_GID=12345
-ENV AEGIR_GID ${AEGIR_GID:-12345}
-
 RUN echo "Creating user aegir with UID $AEGIR_UID and GID $AEGIR_GID"
 
-RUN addgroup --gid $AEGIR_GID aegir
-RUN adduser --uid $AEGIR_UID --gid $AEGIR_GID --system --home /var/aegir aegir
+RUN addgroup --gid $AEGIR_UID aegir
+RUN adduser --uid $AEGIR_UID --gid $AEGIR_UID --system --home /var/aegir aegir
 RUN adduser aegir www-data
 RUN a2enmod rewrite
 RUN ln -s /var/aegir/config/apache.conf /etc/apache2/conf-available/aegir.conf

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -1,20 +1,6 @@
-FROM aegir/hostmaster
 
-# Use --build-arg option when running docker build to set these variables.
-# If wish to "mount" a volume to your host, set AEGIR_UID and AEGIR_GIT to your local user's UID.
-# There are both ARG and ENV lines to make sure the value persists.
-# See https://docs.docker.com/engine/reference/builder/#/arg
-
-# To build a local container, run in this folder:
-#   docker build --build-arg AEGIR_UID=1000 -t aegir/hostmaster:local -f Dockerfile-local .
-
-ARG AEGIR_UID=1000
-ENV AEGIR_UID ${AEGIR_UID:-1000}
-
-USER root
-RUN echo "Changing aegir user's UID to ${AEGIR_UID} ..."
-RUN usermod -u $AEGIR_UID aegir
-RUN groupmod -g $AEGIR_UID aegir
-RUN chown aegir:aegir /var/aegir -R
-
+# The "own" tag is custom built so that the aegir user matches the desired UID, typically from the host.
+# See 'prepare.sh'
+FROM aegir/hostmaster:own
+VOLUME /var/aegir
 USER aegir

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,13 @@
 
 HOSTNAME=`hostname --fqdn`
 
+echo 'ÆGIR | Hello! While we wait for a database...'
+echo 'ÆGIR | Checking /var/aegir...'
+ls -lah /var/aegir
+
+echo 'ÆGIR | Checking /var/aegir/.drush/...'
+ls -lah /var/aegir
+
 # Returns true once mysql can connect.
 # Thanks to http://askubuntu.com/questions/697798/shell-script-how-to-run-script-after-mysql-is-ready
 mysql_ready() {
@@ -11,23 +18,23 @@ mysql_ready() {
 while !(mysql_ready)
 do
    sleep 3
-   echo "waiting for mysql ..."
+   echo "ÆGIR | Waiting for database $AEGIR_DATABASE_SERVER ..."
 done
 
-echo "========================="
-echo "Hostname: $HOSTNAME"
-echo "Database Host: $AEGIR_DATABASE_SERVER"
-echo "Makefile: $AEGIR_MAKEFILE"
-echo "Profile: $AEGIR_PROFILE"
-echo "Version: $AEGIR_VERSION"
-echo "Client Name: $AEGIR_CLIENT_NAME"
-echo "Client Email: $AEGIR_CLIENT_EMAIL"
-
-echo "-------------------------"
-echo "Running: drush hostmaster-install"
-
+echo "ÆGIR | Database active! Commencing Hostmaster Install..."
+echo "ÆGIR | -------------------------"
+echo "ÆGIR | Hostname: $HOSTNAME"
+echo "ÆGIR | Database Host: $AEGIR_DATABASE_SERVER"
+echo "ÆGIR | Makefile: $AEGIR_MAKEFILE"
+echo "ÆGIR | Profile: $AEGIR_PROFILE"
+echo "ÆGIR | Version: $AEGIR_VERSION"
+echo "ÆGIR | Client Name: $AEGIR_CLIENT_NAME"
+echo "ÆGIR | Client Email: $AEGIR_CLIENT_EMAIL"
+echo "ÆGIR | -------------------------"
+echo "ÆGIR | Running: drush cc drush "
 drush cc drush
-
+echo "ÆGIR | -------------------------"
+echo "ÆGIR | Running: drush hostmaster-install"
 drush hostmaster-install -y --strict=0 $HOSTNAME \
   --aegir_db_host=$AEGIR_DATABASE_SERVER \
   --aegir_db_pass=$MYSQL_ROOT_PASSWORD \
@@ -53,13 +60,15 @@ drush hostmaster-install -y --strict=0 $HOSTNAME \
 # Exit on the first failed line.
 set -e
 
-# Output a login link. If hostmaster is already installed, `drush hostmaster-install` doesn't give us a link.
-drush @hostmaster uli
-
-# Run the hosting queue
+echo "ÆGIR | -------------------------"
+echo "ÆGIR | Enabling Hosting Task Queue..."
 drush @hostmaster en hosting_queued -y
 
-drush cc drush
+echo "ÆGIR | -------------------------"
+echo "ÆGIR | Hostmaster Log In Link:  "
+drush @hostmaster uli
 
 # Run whatever is the Docker CMD.
+echo "ÆGIR | -------------------------"
+echo "ÆGIR | Running $@ ..."
 `$@`

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,19 +2,6 @@
 
 HOSTNAME=`hostname --fqdn`
 
-# Install provision
-# /source is made available when running tests.
-if [ -f /source/provision/provision.drush.inc ]; then
-  echo "Installing provision from /source/provision..."
-  mkdir -p /var/aegir/.drush/commands
-  cp -rf /source/provision /var/aegir/.drush/commands/provision
-elif [ -d '/var/aegir/.drush/commands/provision' ] || [ -d '/var/aegir/.drush/provision' ]; then
-  echo "Provision already installed."
-else
-  echo "Installing provision $PROVISION_VERSION with drush..."
-  drush dl provision-$PROVISION_VERSION --destination=/var/aegir/.drush/commands -y
-fi
-
 # Returns true once mysql can connect.
 # Thanks to http://askubuntu.com/questions/697798/shell-script-how-to-run-script-after-mysql-is-ready
 mysql_ready() {

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -39,6 +39,7 @@ echo "ÆGIR | Database active! Commencing Hostmaster Install..."
 echo "ÆGIR | -------------------------"
 echo "ÆGIR | Running: drush cc drush "
 drush cc drush
+
 echo "ÆGIR | -------------------------"
 echo "ÆGIR | Running: drush hostmaster-install"
 drush hostmaster-install -y --strict=0 $HOSTNAME \
@@ -73,6 +74,9 @@ drush @hostmaster en hosting_queued -y
 echo "ÆGIR | -------------------------"
 echo "ÆGIR | Hostmaster Log In Link:  "
 drush @hostmaster uli
+
+echo "ÆGIR | Running: drush cc drush "
+drush cc drush
 
 # Run whatever is the Docker CMD.
 echo "ÆGIR | -------------------------"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,12 +2,26 @@
 
 HOSTNAME=`hostname --fqdn`
 
-echo 'ÆGIR | Hello! While we wait for a database...'
+echo 'ÆGIR | Hello! '
+echo 'ÆGIR | When the database is ready, we will install Aegir with the following options:'
+echo "ÆGIR | -------------------------"
+echo "ÆGIR | Hostname: $HOSTNAME"
+echo "ÆGIR | Database Host: $AEGIR_DATABASE_SERVER"
+echo "ÆGIR | Makefile: $AEGIR_MAKEFILE"
+echo "ÆGIR | Profile: $AEGIR_PROFILE"
+echo "ÆGIR | Version: $AEGIR_VERSION"
+echo "ÆGIR | Client Name: $AEGIR_CLIENT_NAME"
+echo "ÆGIR | Client Email: $AEGIR_CLIENT_EMAIL"
+echo "ÆGIR | -------------------------"
+echo "ÆGIR | TIP: To receive an email when the container is ready, add the AEGIR_CLIENT_EMAIL environment variable to your docker-compose.yml file."
+echo "ÆGIR | -------------------------"
 echo 'ÆGIR | Checking /var/aegir...'
 ls -lah /var/aegir
-
+echo "ÆGIR | -------------------------"
 echo 'ÆGIR | Checking /var/aegir/.drush/...'
 ls -lah /var/aegir
+echo "ÆGIR | -------------------------"
+
 
 # Returns true once mysql can connect.
 # Thanks to http://askubuntu.com/questions/697798/shell-script-how-to-run-script-after-mysql-is-ready
@@ -18,18 +32,10 @@ mysql_ready() {
 while !(mysql_ready)
 do
    sleep 3
-   echo "ÆGIR | Waiting for database $AEGIR_DATABASE_SERVER ..."
+   echo "ÆGIR | Waiting for database host '$AEGIR_DATABASE_SERVER' ..."
 done
 
 echo "ÆGIR | Database active! Commencing Hostmaster Install..."
-echo "ÆGIR | -------------------------"
-echo "ÆGIR | Hostname: $HOSTNAME"
-echo "ÆGIR | Database Host: $AEGIR_DATABASE_SERVER"
-echo "ÆGIR | Makefile: $AEGIR_MAKEFILE"
-echo "ÆGIR | Profile: $AEGIR_PROFILE"
-echo "ÆGIR | Version: $AEGIR_VERSION"
-echo "ÆGIR | Client Name: $AEGIR_CLIENT_NAME"
-echo "ÆGIR | Client Email: $AEGIR_CLIENT_EMAIL"
 echo "ÆGIR | -------------------------"
 echo "ÆGIR | Running: drush cc drush "
 drush cc drush

--- a/releases/Dockerfile-3.6
+++ b/releases/Dockerfile-3.6
@@ -1,4 +1,4 @@
-FROM aegir:hostmaster
+FROM aegir/hostmaster
 
 ENV AEGIR_CLIENT_EMAIL aegir@aegir.docker
 ENV AEGIR_CLIENT_NAME admin
@@ -6,12 +6,17 @@ ENV AEGIR_PROFILE hostmaster
 ENV AEGIR_VERSION 7.x-3.6
 ENV PROVISION_VERSION 7.x-3.6
 
+USER root
+
+# Remove stock provision, install provision-$PROVISION_VERSION
+RUN rm -rf /usr/share/drush/commands/provision
+RUN drush dl --destination=/usr/share/drush/commands provision-$PROVISION_VERSION -y
+
+USER aegir
+
 # For Releases:
 ENV AEGIR_MAKEFILE http://cgit.drupalcode.org/provision/plain/aegir-release.make?h=$AEGIR_VERSION
 
 # Prepare hostmaster platform.
 RUN drush make $AEGIR_MAKEFILE /var/aegir/$AEGIR_PROFILE-$AEGIR_VERSION
-
-# docker-entrypoint.sh waits for mysql and runs hostmaster install
-ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["drush @hostmaster hosting-queued"]
+RUN drush cc drush


### PR DESCRIPTION
This PR does a few things:

1. Installs provision in the global drush command space.
2. Removes provision install from docker-entrypoint.sh
3. Fixes the release Dockerfile for 3.6
4. Improves the docker-entrypoint.sh script to show more info earlier, and to include clear Aegir branding.
5. Fixes the UID issue by using build-args on the main hostmaster Dockerfile.