### PR TITLE
Fixing travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,4 +56,5 @@ before_install:
 script:
 
   # Launch docker-compose.yml file within tests repo.
-  - docker-compose run -T --file docker-compose-tests.yml hostmaster
+  - docker-compose --file docker-compose-tests.yml run -T hostmaster
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,14 @@ before_install:
   # Debugging users
   - whoami
   - id -u
+  - docker --version
+  - docker-compose --version
 
   # upgrade docker-engine to specific version
   - git clone http://github.com/aegir-project/tests.git
   - cd tests
   - git checkout $AEGIR_TESTS_VERSION
-  - sudo bash travis/prepare-docker.sh
+#  - sudo bash travis/prepare-docker.sh
 
   - sudo mkdir vendor
   - sudo chmod 777 vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,5 +56,5 @@ before_install:
 script:
 
   # Launch docker-compose.yml file within tests repo.
-  - docker-compose --file docker-compose-tests.yml run -T hostmaster
+  - docker-compose --file docker-compose-tests.yml run -T -e TERM=xterm hostmaster
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,4 +56,4 @@ before_install:
 script:
 
   # Launch docker-compose.yml file within tests repo.
-  - docker-compose -T --file docker-compose-tests.yml run hostmaster
+  - docker-compose run -T --file docker-compose-tests.yml hostmaster

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,10 +50,10 @@ before_install:
   - cd ..
 
   # First build stock image, and one for own user.
-  - sudo docker build --rm -t aegir/hostmaster:dev .
-  - sudo docker build --rm -t aegir/hostmaster:local -f Dockerfile-local --build-arg NEW_UID=$UID .
+  - docker build --rm -t aegir/hostmaster:dev .
+  - docker build --rm -t aegir/hostmaster:local -f Dockerfile-local --build-arg NEW_UID=$UID .
 
 script:
 
   # Launch docker-compose.yml file within tests repo.
-  - sudo docker-compose -T --file docker-compose-tests.yml run hostmaster
+  - docker-compose -T --file docker-compose-tests.yml run hostmaster

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   hostmaster:
-    image: aegir/hostmaster
+    image: aegir/hostmaster:dev
     command:
       - run-tests.sh
     ports:
@@ -16,8 +16,6 @@ services:
     environment:
       VIRTUAL_HOST: aegir.local.computer
       MYSQL_ROOT_PASSWORD: strongpassword
-    tty: true
-    stdin_open: true
 
   database:
     image: mariadb


### PR DESCRIPTION
Still not sure what's going on but DevShop install works fine on these same containers.

I noticed aegir docker-compose run does not use -T option, but it does in devshop, so I started by trying to add that flag, but docker-compose didn't know what it was, so our versions must be off.

The new travis images have latest docker, so let's start by not reinstalling docker and docker-compose.