### PR TITLE
hosting_https complains about missing curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update -qq && apt-get install -y -qq\
   php5-mysql \
   php-pear \
   php5-curl \
+  curl \
   postfix \
   sudo \
   rsync \


### PR DESCRIPTION
To get hosting_https with let's encrypt working I had to manually install curl into the container.
Since it has been a request on an issue and hosting_https is part of the standard hostmaster profile it should work and therefore I think it would be useful to have curl by default installed in the container. I don't think it would add much bloat and maybe some users would get a better experience.

Hope this helps!
best regards and thanks for your great work!